### PR TITLE
Added option to use latest development build (HEAD)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 - minikube-version (optional)
   - description: Choose a specific minikube version
   - default: latest
-  - format: X.X.X
+  - options: version in format of X.X.X, 'latest' for the latest stable build, or 'HEAD' for the latest development build
   - example: 1.24.0
 - driver (optional)
   - description: Choose a specific driver

--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ branding:
   color: 'blue'
 inputs:
   minikube-version:
-    description: 'Choose a specific version of minikube'
+    description: 'Choose a specific version of minikube, "latest" for the latest stable build, or "HEAD" for the latest development build'
     required: false
     default: 'latest'
   action:

--- a/dist/index.js
+++ b/dist/index.js
@@ -1595,7 +1595,7 @@ const minikube_1 = __webpack_require__(928);
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
-            yield minikube_1.downloadMinikube(core.getInput('minikube-version'));
+            yield minikube_1.downloadMinikube(core.getInput('minikube-version').toLowerCase());
             yield minikube_1.startMinikube();
         }
         catch (error) {
@@ -5385,11 +5385,11 @@ const path = __importStar(__webpack_require__(622));
 function startMinikube() {
     return __awaiter(this, void 0, void 0, function* () {
         const args = ['start', '--wait', 'all'];
-        const driver = core.getInput('driver');
+        const driver = core.getInput('driver').toLowerCase();
         if (driver !== '') {
             args.push('--driver', driver);
         }
-        const containerRuntime = core.getInput('container-runtime');
+        const containerRuntime = core.getInput('container-runtime').toLowerCase();
         if (containerRuntime !== '') {
             args.push('--container-runtime', containerRuntime);
         }
@@ -5401,10 +5401,14 @@ function getDownloadUrl(version) {
     const osPlat = os.platform();
     const platform = osPlat === 'win32' ? 'windows' : osPlat;
     const suffix = osPlat === 'win32' ? '.exe' : '';
-    if (version === 'latest') {
-        return `https://github.com/kubernetes/minikube/releases/latest/download/minikube-${platform}-amd64${suffix}`;
+    switch (version) {
+        case 'latest':
+            return `https://github.com/kubernetes/minikube/releases/latest/download/minikube-${platform}-amd64${suffix}`;
+        case 'head':
+            return `https://storage.googleapis.com/minikube-builds/master/minikube-${platform}-amd64${suffix}`;
+        default:
+            return `https://github.com/kubernetes/minikube/releases/download/v${version}/minikube-${platform}-amd64${suffix}`;
     }
-    return `https://github.com/kubernetes/minikube/releases/download/v${version}/minikube-${platform}-amd64${suffix}`;
 }
 exports.getDownloadUrl = getDownloadUrl;
 function downloadMinikube(version) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,7 +4,7 @@ import {downloadMinikube, startMinikube} from './minikube';
 // main thing :)
 async function run(): Promise<void> {
   try {
-    await downloadMinikube(core.getInput('minikube-version'));
+    await downloadMinikube(core.getInput('minikube-version').toLowerCase());
     await startMinikube();
   } catch (error) {
     core.setFailed(error.message);

--- a/src/minikube.ts
+++ b/src/minikube.ts
@@ -7,11 +7,11 @@ import * as path from 'path';
 
 export async function startMinikube(): Promise<void> {
   const args = ['start', '--wait', 'all']
-  const driver = core.getInput('driver')
+  const driver = core.getInput('driver').toLowerCase()
   if (driver !== '') {
 	  args.push('--driver', driver)
   }
-  const containerRuntime = core.getInput('container-runtime')
+  const containerRuntime = core.getInput('container-runtime').toLowerCase()
   if (containerRuntime !== '') {
 	  args.push('--container-runtime', containerRuntime)
   }
@@ -22,10 +22,14 @@ export function getDownloadUrl(version: string): string {
   const osPlat = os.platform();
   const platform = osPlat === 'win32' ? 'windows' : osPlat;
   const suffix = osPlat === 'win32' ? '.exe' : '';
-  if (version === 'latest') {
-    return `https://github.com/kubernetes/minikube/releases/latest/download/minikube-${platform}-amd64${suffix}`;
+  switch (version) {
+    case 'latest':
+      return `https://github.com/kubernetes/minikube/releases/latest/download/minikube-${platform}-amd64${suffix}`;
+    case 'head':
+      return `https://storage.googleapis.com/minikube-builds/master/minikube-${platform}-amd64${suffix}`
+    default:
+      return `https://github.com/kubernetes/minikube/releases/download/v${version}/minikube-${platform}-amd64${suffix}`;
   }
-  return `https://github.com/kubernetes/minikube/releases/download/v${version}/minikube-${platform}-amd64${suffix}`;
 }
 
 export async function downloadMinikube(version: string): Promise<void> {


### PR DESCRIPTION
- Added the option to use latest development build by passing `head` to `minikube-version`
- Made `minikube-version`, `driver`, and `container-runtime` be case-insensitive