### PR TITLE
Install all none driver deps

### DIFF
--- a/src/minikube.ts
+++ b/src/minikube.ts
@@ -22,9 +22,60 @@ export function setArgs(args: string[]) {
   })
 }
 
+export async function installCriDocker(): Promise<void> {
+  const urlBase =
+    'https://storage.googleapis.com/setup-minikube/cri-dockerd/v0.2.3/'
+  const binaryDownload = downloadTool(urlBase + 'cri-dockerd')
+  const serviceDownload = downloadTool(urlBase + 'cri-docker.service')
+  const socketDownload = downloadTool(urlBase + 'cri-docker.socket')
+  await exec('chmod', ['+x', await binaryDownload])
+  await exec('sudo', ['mv', await binaryDownload, '/usr/bin/cri-dockerd'])
+  await exec('sudo', [
+    'mv',
+    await serviceDownload,
+    '/usr/lib/systemd/system/cri-docker.service',
+  ])
+  await exec('sudo', [
+    'mv',
+    await socketDownload,
+    '/usr/lib/systemd/system/cri-docker.socket',
+  ])
+}
+
+export async function installConntrackSocat(): Promise<void> {
+  await exec('sudo', ['apt-get', 'update', '-qq'])
+  await exec('sudo', ['apt-get', '-qq', '-y', 'install', 'conntrack', 'socat'])
+}
+
+export async function installCrictl(): Promise<void> {
+  const crictlURL =
+    'https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.17.0/crictl-v1.17.0-linux-amd64.tar.gz'
+  const crictlDownload = downloadTool(crictlURL)
+  await exec('sudo', [
+    'tar',
+    'zxvf',
+    await crictlDownload,
+    '-C',
+    '/usr/local/bin',
+  ])
+}
+
+export async function installNoneDriverDeps(): Promise<void> {
+  const driver = getInput('driver').toLowerCase()
+  if (driver !== 'none') {
+    return
+  }
+  await Promise.all([
+    installCriDocker(),
+    installConntrackSocat(),
+    installCrictl(),
+  ])
+}
+
 export async function startMinikube(): Promise<void> {
   const args = ['start', '--wait', 'all']
   setArgs(args)
+  await installNoneDriverDeps()
   await exec('minikube', args)
 }
 


### PR DESCRIPTION
- Installs the following if user is using the `none` driver
  - cri-docker
  - conntrack
  - socat
  - crictl
- Runs the installs async to minimize setup time

Proof of success:
```
/usr/bin/chmod +x /home/runner/work/_temp/32214921-ca3c-44cc-83c9-7e5e42ae2ce0
/usr/bin/sudo apt-get update -qq
/usr/bin/sudo tar zxvf /home/runner/work/_temp/dbc55157-d920-4a45-a4f9-1233e9e642ec -C /usr/local/bin
crictl
/usr/bin/chmod +x /home/runner/work/_temp/fb7e1637-53d3-4634-93d6-415310f3faef
/usr/bin/sudo mv /home/runner/work/_temp/fb7e1637-53d3-4634-93d6-415310f3faef /usr/bin/cri-dockerd
/usr/bin/sudo mv /home/runner/work/_temp/896b564c-0659-494a-a92b-bb294b7c87c4 /usr/lib/systemd/system/cri-docker.service
/usr/bin/sudo mv /home/runner/work/_temp/88215035-c253-4de6-a75e-687d90be8bc6 /usr/lib/systemd/system/cri-docker.socket
/usr/bin/sudo apt-get -qq -y install conntrack socat
Selecting previously unselected package conntrack.
(Reading database ... 
(Reading database ... 5%
(Reading database ... 10%
(Reading database ... 15%
(Reading database ... 20%
(Reading database ... 25%
(Reading database ... 30%
(Reading database ... 35%
(Reading database ... 40%
(Reading database ... 45%
(Reading database ... 50%
(Reading database ... 55%
(Reading database ... 60%
(Reading database ... 65%
(Reading database ... 70%
(Reading database ... 75%
(Reading database ... 80%
(Reading database ... 85%
(Reading database ... 90%
(Reading database ... 95%
(Reading database ... 100%
(Reading database ... 235562 files and directories currently installed.)
Preparing to unpack .../conntrack_1%3a1.4.5-2_amd64.deb ...
Unpacking conntrack (1:1.4.5-2) ...
Selecting previously unselected package socat.
Preparing to unpack .../socat_1.7.3.3-2_amd64.deb ...
Unpacking socat (1.7.3.3-2) ...
Setting up conntrack (1:1.4.5-2) ...
Setting up socat (1.7.3.3-2) ...
Processing triggers for man-db (2.9.1-1) ...
/home/runner/bin/minikube start --wait all --driver none --cni auto
* minikube v1.26.0 on Ubuntu 20.04
* Using the none driver based on user configuration
* Starting control plane node minikube in cluster minikube
* Running on localhost (CPUs=2, Memory=6946MB, Disk=85173MB) ...
* OS release is Ubuntu 20.04.4 LTS
* Preparing Kubernetes v1.24.1 on Docker 20.10.17+azure-1 ...
  - kubelet.resolv-conf=/run/systemd/resolve/resolv.conf
  - Generating certificates and keys ...
  - Booting up control plane ...
  - Configuring RBAC rules ...
* Configuring local host environment ...
* 
! The 'none' driver is designed for experts who need to integrate with an existing VM
* Most users should use the newer 'docker' driver instead, which does not require root!
* For more information, see: https://minikube.sigs.k8s.io/docs/reference/drivers/none/
* 
! kubectl and minikube configuration will be stored in /home/runner
! To use kubectl or minikube commands as your own user, you may need to relocate them. For example, to overwrite your own settings, run:
* 
  - sudo mv /home/runner/.kube /home/runner/.minikube $HOME
  - sudo chown -R $USER $HOME/.kube $HOME/.minikube
* 
* This can also be done automatically by setting the env var CHANGE_MINIKUBE_NONE_USER=true
* Verifying Kubernetes components...
  - Using image gcr.io/k8s-minikube/storage-provisioner:v5
* Enabled addons: default-storageclass, storage-provisioner
* Done! kubectl is now configured to use "minikube" cluster and "default" namespace by default
```