### PR TITLE
feat(none-driver): support Kubernetes v1.26

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,4 +59,10 @@ jobs:
       # Should be fine
       - run: |
           cat ~/.minikube/profiles/minikube/config.json | grep ValidatingAdmissionPolicy
-
+  test-none-driver:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+      - uses: ./
+        with:
+          driver: none

--- a/dist/index.js
+++ b/dist/index.js
@@ -248,8 +248,11 @@ exports.installNoneDriverDeps = void 0;
 const core_1 = __nccwpck_require__(2186);
 const exec_1 = __nccwpck_require__(1514);
 const tool_cache_1 = __nccwpck_require__(7784);
+const cniPluginsVersion = 'v1.2.0';
+const criDockerVersion = 'v0.3.1';
+const crictlVersion = 'v1.26.1';
 const installCniPlugins = () => __awaiter(void 0, void 0, void 0, function* () {
-    const cniPluginsURL = 'https://github.com/containernetworking/plugins/releases/download/v1.2.0/cni-plugins-linux-amd64-v1.2.0.tgz';
+    const cniPluginsURL = `https://github.com/containernetworking/plugins/releases/download/${cniPluginsVersion}/cni-plugins-linux-amd64-${cniPluginsVersion}.tgz`;
     const cniPluginsDownload = (0, tool_cache_1.downloadTool)(cniPluginsURL);
     yield (0, exec_1.exec)('sudo', ['mkdir', '-p', '/opt/cni/bin']);
     yield (0, exec_1.exec)('sudo', [
@@ -270,7 +273,7 @@ const installCriDocker = () => __awaiter(void 0, void 0, void 0, function* () {
         },
     };
     yield (0, exec_1.exec)('lsb_release', ['--short', '--codename'], options);
-    const criDockerURL = `https://github.com/Mirantis/cri-dockerd/releases/download/v0.3.1/cri-dockerd_0.3.1.3-0.ubuntu-${codename}_amd64.deb`;
+    const criDockerURL = `https://github.com/Mirantis/cri-dockerd/releases/download/${criDockerVersion}/cri-dockerd_${criDockerVersion.replace(/^v/, '')}.3-0.ubuntu-${codename}_amd64.deb`;
     const criDockerDownload = (0, tool_cache_1.downloadTool)(criDockerURL);
     yield (0, exec_1.exec)('sudo', ['dpkg', '--install', yield criDockerDownload]);
 });
@@ -281,7 +284,7 @@ const installConntrackSocatCriDocker = () => __awaiter(void 0, void 0, void 0, f
     yield installCriDocker();
 });
 const installCrictl = () => __awaiter(void 0, void 0, void 0, function* () {
-    const crictlURL = 'https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.26.0/crictl-v1.26.0-linux-amd64.tar.gz';
+    const crictlURL = `https://github.com/kubernetes-sigs/cri-tools/releases/download/${crictlVersion}/crictl-${crictlVersion}-linux-amd64.tar.gz`;
     const crictlDownload = (0, tool_cache_1.downloadTool)(crictlURL);
     yield (0, exec_1.exec)('sudo', [
         'tar',

--- a/src/none-driver.ts
+++ b/src/none-driver.ts
@@ -2,34 +2,46 @@ import {getInput} from '@actions/core'
 import {exec} from '@actions/exec'
 import {downloadTool} from '@actions/tool-cache'
 
-const installCriDocker = async (): Promise<void> => {
-  const urlBase =
-    'https://storage.googleapis.com/setup-minikube/cri-dockerd/v0.2.3/'
-  const binaryDownload = downloadTool(urlBase + 'cri-dockerd')
-  const serviceDownload = downloadTool(urlBase + 'cri-docker.service')
-  const socketDownload = downloadTool(urlBase + 'cri-docker.socket')
-  await exec('chmod', ['+x', await binaryDownload])
-  await exec('sudo', ['mv', await binaryDownload, '/usr/bin/cri-dockerd'])
+const installCniPlugins = async (): Promise<void> => {
+  const cniPluginsURL =
+    'https://github.com/containernetworking/plugins/releases/download/v1.2.0/cni-plugins-linux-amd64-v1.2.0.tgz'
+  const cniPluginsDownload = downloadTool(cniPluginsURL)
+  await exec('sudo', ['mkdir', '-p', '/opt/cni/bin'])
   await exec('sudo', [
-    'mv',
-    await serviceDownload,
-    '/usr/lib/systemd/system/cri-docker.service',
-  ])
-  await exec('sudo', [
-    'mv',
-    await socketDownload,
-    '/usr/lib/systemd/system/cri-docker.socket',
+    'tar',
+    'zxvf',
+    await cniPluginsDownload,
+    '-C',
+    '/opt/cni/bin',
   ])
 }
 
-const installConntrackSocat = async (): Promise<void> => {
+const installCriDocker = async (): Promise<void> => {
+  let codename = ''
+  const options = {
+    listeners: {
+      stdout: (data: Buffer) => {
+        codename += data.toString()
+      },
+    },
+  }
+  await exec('lsb_release', ['--short', '--codename'], options)
+  const criDockerURL =
+    `https://github.com/Mirantis/cri-dockerd/releases/download/v0.3.1/cri-dockerd_0.3.1.3-0.ubuntu-${codename}_amd64.deb`
+  const criDockerDownload = downloadTool(criDockerURL)
+  await exec('sudo', ['dpkg', '--install', await criDockerDownload])
+}
+
+const installConntrackSocatCriDocker = async (): Promise<void> => {
   await exec('sudo', ['apt-get', 'update', '-qq'])
   await exec('sudo', ['apt-get', '-qq', '-y', 'install', 'conntrack', 'socat'])
+  // Need to wait for the dpkg frontend lock to install cri-docker
+  await installCriDocker()
 }
 
 const installCrictl = async (): Promise<void> => {
   const crictlURL =
-    'https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.17.0/crictl-v1.17.0-linux-amd64.tar.gz'
+    'https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.26.0/crictl-v1.26.0-linux-amd64.tar.gz'
   const crictlDownload = downloadTool(crictlURL)
   await exec('sudo', [
     'tar',
@@ -40,14 +52,20 @@ const installCrictl = async (): Promise<void> => {
   ])
 }
 
+const makeCniDirectoryReadable = async (): Promise<void> => {
+  // created by podman package with 700 root:root
+  await exec('sudo', ['chmod', '755', '/etc/cni/net.d'])
+}
+
 export const installNoneDriverDeps = async (): Promise<void> => {
   const driver = getInput('driver').toLowerCase()
   if (driver !== 'none') {
     return
   }
   await Promise.all([
-    installCriDocker(),
-    installConntrackSocat(),
+    installCniPlugins(),
+    installConntrackSocatCriDocker(),
     installCrictl(),
+    makeCniDirectoryReadable(),
   ])
 }

--- a/src/none-driver.ts
+++ b/src/none-driver.ts
@@ -2,9 +2,12 @@ import {getInput} from '@actions/core'
 import {exec} from '@actions/exec'
 import {downloadTool} from '@actions/tool-cache'
 
+const cniPluginsVersion = 'v1.2.0'
+const criDockerVersion = 'v0.3.1'
+const crictlVersion = 'v1.26.1'
+
 const installCniPlugins = async (): Promise<void> => {
-  const cniPluginsURL =
-    'https://github.com/containernetworking/plugins/releases/download/v1.2.0/cni-plugins-linux-amd64-v1.2.0.tgz'
+  const cniPluginsURL = `https://github.com/containernetworking/plugins/releases/download/${cniPluginsVersion}/cni-plugins-linux-amd64-${cniPluginsVersion}.tgz`
   const cniPluginsDownload = downloadTool(cniPluginsURL)
   await exec('sudo', ['mkdir', '-p', '/opt/cni/bin'])
   await exec('sudo', [
@@ -26,8 +29,10 @@ const installCriDocker = async (): Promise<void> => {
     },
   }
   await exec('lsb_release', ['--short', '--codename'], options)
-  const criDockerURL =
-    `https://github.com/Mirantis/cri-dockerd/releases/download/v0.3.1/cri-dockerd_0.3.1.3-0.ubuntu-${codename}_amd64.deb`
+  const criDockerURL = `https://github.com/Mirantis/cri-dockerd/releases/download/${criDockerVersion}/cri-dockerd_${criDockerVersion.replace(
+    /^v/,
+    ''
+  )}.3-0.ubuntu-${codename}_amd64.deb`
   const criDockerDownload = downloadTool(criDockerURL)
   await exec('sudo', ['dpkg', '--install', await criDockerDownload])
 }
@@ -40,8 +45,7 @@ const installConntrackSocatCriDocker = async (): Promise<void> => {
 }
 
 const installCrictl = async (): Promise<void> => {
-  const crictlURL =
-    'https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.26.0/crictl-v1.26.0-linux-amd64.tar.gz'
+  const crictlURL = `https://github.com/kubernetes-sigs/cri-tools/releases/download/${crictlVersion}/crictl-${crictlVersion}-linux-amd64.tar.gz`
   const crictlDownload = downloadTool(crictlURL)
   await exec('sudo', [
     'tar',


### PR DESCRIPTION
Hello there! :wave:

* Kubernetes v1.26 requires the container runtime to support the `cri-api` v1, this was added in `cri-dockerd` v0.3.0:
  * [Mirantis/cri-dockerd@`v0.3.1` (release)](https://github.com/Mirantis/cri-dockerd/releases/tag/v0.3.1)
  * [Mirantis/cri-dockerd@`v0.3.0` (release)](https://github.com/Mirantis/cri-dockerd/releases/tag/v0.3.0)
  
  Change the install to use the `.deb` package, otherwise it would require to publish the release at `storage.googleapis.com/setup-minikube/cri-dockerd`
* Install CNI plugins. Since Minikube v1.29.0, `cri-dockerd` defaults to the `bridge` plugin: kubernetes/minikube@fd549f396dbd39385baefe88dcead0ccf99f1bff. Fixes #73

* Bump `cri-tools`, simply because they were from a fairly old version