### PR TITLE
Skip caching if dir doesn't exist

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -20,6 +20,7 @@ exports.saveCaches = exports.getMinikubeVersion = exports.restoreCaches = void 0
 const cache_1 = __nccwpck_require__(7799);
 const core_1 = __nccwpck_require__(2186);
 const exec_1 = __nccwpck_require__(1514);
+const fs_1 = __nccwpck_require__(7147);
 const os_1 = __nccwpck_require__(2037);
 const path_1 = __nccwpck_require__(1017);
 const restoreCaches = () => __awaiter(void 0, void 0, void 0, function* () {
@@ -54,11 +55,11 @@ const saveCaches = (cacheHits) => __awaiter(void 0, void 0, void 0, function* ()
         return;
     }
     const minikubeVersion = yield (0, exports.getMinikubeVersion)();
-    const isoCache = saveCache('iso', cacheHits.iso, minikubeVersion);
-    const kicCache = saveCache('kic', cacheHits.kic, minikubeVersion);
-    yield saveCache('preloaded-tarball', cacheHits.preload, minikubeVersion);
-    yield isoCache;
-    yield kicCache;
+    yield Promise.all([
+        saveCache('iso', cacheHits.iso, minikubeVersion),
+        saveCache('kic', cacheHits.kic, minikubeVersion),
+        saveCache('preloaded-tarball', cacheHits.preload, minikubeVersion),
+    ]);
 });
 exports.saveCaches = saveCaches;
 const restoreCache = (name, minikubeVersion) => __awaiter(void 0, void 0, void 0, function* () {
@@ -68,8 +69,12 @@ const saveCache = (name, cacheHit, minikubeVersion) => __awaiter(void 0, void 0,
     if (cacheHit) {
         return;
     }
+    const cachePaths = getCachePaths(name);
+    if (!(0, fs_1.existsSync)(cachePaths[0])) {
+        return;
+    }
     try {
-        yield (0, cache_1.saveCache)(getCachePaths(name), getCacheKey(name, minikubeVersion));
+        yield (0, cache_1.saveCache)(cachePaths, getCacheKey(name, minikubeVersion));
     }
     catch (error) {
         console.log(name + error);


### PR DESCRIPTION
Fixes https://github.com/medyagh/setup-minikube/issues/102

Check if the directory exists before trying to cache it, this will prevent error messages that can confuse the user. This is usually caused because we try caching the kicbase and ISO, but only one will exist, so the non-existing one throws a message when it fails to cache.

**Before:**
```
* Done! kubectl is now configured to use "minikube" cluster and "default" namespace by default
/home/runner/bin/minikube version --short
v1.29.0
isoError: Path Validation Error: Path(s) specified in the action for caching do(es) not exist, hence no cache is being saved.
```

**After:**
```
* Done! kubectl is now configured to use "minikube" cluster and "default" namespace by default
/home/runner/bin/minikube version --short
v1.29.0
```