### PR TITLE
Copy the file and remove the original

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -145,7 +145,8 @@ const downloadMinikube = (version) => __awaiter(void 0, void 0, void 0, function
     const binPath = (0, os_1.platform)() === 'darwin' ? '/Users/runner/bin' : '/home/runner/bin';
     yield (0, io_1.mkdirP)(binPath);
     yield (0, exec_1.exec)('chmod', ['+x', downloadPath]);
-    yield (0, io_1.mv)(downloadPath, (0, path_1.join)(binPath, 'minikube'));
+    yield (0, io_1.cp)(downloadPath, (0, path_1.join)(binPath, 'minikube'));
+    yield (0, io_1.rmRF)(downloadPath);
     (0, core_1.addPath)(binPath);
 });
 exports.downloadMinikube = downloadMinikube;

--- a/src/download.ts
+++ b/src/download.ts
@@ -1,6 +1,6 @@
 import {addPath} from '@actions/core'
 import {exec} from '@actions/exec'
-import {mkdirP, mv} from '@actions/io'
+import {mkdirP, cp, rmRF} from '@actions/io'
 import {downloadTool} from '@actions/tool-cache'
 import {platform as getPlatform} from 'os'
 import {join} from 'path'
@@ -26,6 +26,7 @@ export const downloadMinikube = async (version: string): Promise<void> => {
     getPlatform() === 'darwin' ? '/Users/runner/bin' : '/home/runner/bin'
   await mkdirP(binPath)
   await exec('chmod', ['+x', downloadPath])
-  await mv(downloadPath, join(binPath, 'minikube'))
+  await cp(downloadPath, join(binPath, 'minikube'))
+  await rmRF(downloadPath)
   addPath(binPath)
 }


### PR DESCRIPTION
Hi :wave:,

There is an issue running `setup-minikube` in self-hosted GitHub actions runners due to the tmp folder being on a different partition:
```
Error: EXDEV: cross-device link not permitted, rename '/runner/_work/_temp/631b8ac3-0772-449c-b657-cb5e6ebd055e' -> '/home/runner/bin/minikube'
```
It's related to this bug:
- https://github.com/actions/toolkit/issues/706

The underlying `io.mv` tries to rename the file to the new location which does not work across partitions.

To workaround that issue, this commit makes the code `io.cp` the file and `io.rmRF` the original.


Kind regards,
Stephen