### PR TITLE
Add `install-path` action argument to customise where minikube executables get installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,14 @@ By default setup-minikube caches the ISO, kicbase, and preload using GitHub Acti
 </details>
 
 <details>
+  <summary>bin-path (optional)</summary>
+  <pre>
+    - default: ''
+    - value: Path where the executables (minikube) will get installed. Useful when having multiple self-hosted runners on one machine.
+  </pre>
+</details>
+
+<details>
   <summary>insecure-registry (optional)</summary>
   <pre>
     - default: ''

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ By default setup-minikube caches the ISO, kicbase, and preload using GitHub Acti
 </details>
 
 <details>
-  <summary>bin-path (optional)</summary>
+  <summary>install-path (optional)</summary>
   <pre>
     - default: ''
     - value: Path where the executables (minikube) will get installed. Useful when having multiple self-hosted runners on one machine.

--- a/action.yml
+++ b/action.yml
@@ -61,7 +61,7 @@ inputs:
     description: 'Mount the source directory from your host into the target directory inside the cluster (format: <source directory>:<target directory>)'
     required: false
     default: ''
-  bin-path:
+  install-path:
     description: 'Path where the executables (minikube) will get installed. Useful when having multiple self-hosted runners on one machine.'
     required: false
     default: ''

--- a/action.yml
+++ b/action.yml
@@ -61,6 +61,10 @@ inputs:
     description: 'Mount the source directory from your host into the target directory inside the cluster (format: <source directory>:<target directory>)'
     required: false
     default: ''
+  bin-path:
+    description: 'Path where the executables (minikube) will get installed. Useful when having multiple self-hosted runners on one machine.'
+    required: false
+    default: ''
   wait:
     description: 'comma separated list of Kubernetes components to verify and wait for after starting a cluster. defaults to "apiserver,system_pods", available options: "apiserver,system_pods,default_sa,apps_running,node_ready,kubelet". Other acceptable values are "all" or "none", "true" and "false"'
     required: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -139,17 +139,18 @@ const getDownloadURL = (version) => {
     }
 };
 exports.getDownloadURL = getDownloadURL;
-const downloadMinikube = (version, binPath) => __awaiter(void 0, void 0, void 0, function* () {
+const downloadMinikube = (version, installPath) => __awaiter(void 0, void 0, void 0, function* () {
     const url = (0, exports.getDownloadURL)(version);
     const downloadPath = yield (0, tool_cache_1.downloadTool)(url);
-    if (!binPath) {
-        binPath = (0, os_1.platform)() === 'darwin' ? '/Users/runner/bin' : '/home/runner/bin';
+    if (!installPath) {
+        installPath =
+            (0, os_1.platform)() === 'darwin' ? '/Users/runner/bin' : '/home/runner/bin';
     }
-    yield (0, io_1.mkdirP)(binPath);
+    yield (0, io_1.mkdirP)(installPath);
     yield (0, exec_1.exec)('chmod', ['+x', downloadPath]);
-    yield (0, io_1.cp)(downloadPath, (0, path_1.join)(binPath, 'minikube'));
+    yield (0, io_1.cp)(downloadPath, (0, path_1.join)(installPath, 'minikube'));
     yield (0, io_1.rmRF)(downloadPath);
-    (0, core_1.addPath)(binPath);
+    (0, core_1.addPath)(installPath);
 });
 exports.downloadMinikube = downloadMinikube;
 
@@ -223,8 +224,8 @@ const run = () => __awaiter(void 0, void 0, void 0, function* () {
     try {
         let minikubeVersion = (0, core_1.getInput)('minikube-version').toLowerCase();
         minikubeVersion = minikubeVersion === 'stable' ? 'latest' : minikubeVersion;
-        const binPath = (0, core_1.getInput)('bin-path');
-        yield (0, download_1.downloadMinikube)(minikubeVersion, binPath);
+        const installPath = (0, core_1.getInput)('install-path');
+        yield (0, download_1.downloadMinikube)(minikubeVersion, installPath);
         yield (0, start_1.startMinikube)();
     }
     catch (error) {
@@ -350,8 +351,8 @@ const startMinikube = () => __awaiter(void 0, void 0, void 0, function* () {
     (0, inputs_1.setArgs)(args);
     const cacheHits = yield (0, cache_1.restoreCaches)();
     yield (0, none_driver_1.installNoneDriverDeps)();
-    const binPath = (0, core_1.getInput)('bin-path');
-    yield (0, exec_1.exec)('minikube', args, { cwd: binPath });
+    const installPath = (0, core_1.getInput)('install-path');
+    yield (0, exec_1.exec)('minikube', args, { cwd: installPath });
     yield (0, cache_1.saveCaches)(cacheHits);
 });
 exports.startMinikube = startMinikube;

--- a/dist/index.js
+++ b/dist/index.js
@@ -139,10 +139,12 @@ const getDownloadURL = (version) => {
     }
 };
 exports.getDownloadURL = getDownloadURL;
-const downloadMinikube = (version) => __awaiter(void 0, void 0, void 0, function* () {
+const downloadMinikube = (version, binPath) => __awaiter(void 0, void 0, void 0, function* () {
     const url = (0, exports.getDownloadURL)(version);
     const downloadPath = yield (0, tool_cache_1.downloadTool)(url);
-    const binPath = (0, os_1.platform)() === 'darwin' ? '/Users/runner/bin' : '/home/runner/bin';
+    if (!binPath) {
+        binPath = (0, os_1.platform)() === 'darwin' ? '/Users/runner/bin' : '/home/runner/bin';
+    }
     yield (0, io_1.mkdirP)(binPath);
     yield (0, exec_1.exec)('chmod', ['+x', downloadPath]);
     yield (0, io_1.cp)(downloadPath, (0, path_1.join)(binPath, 'minikube'));
@@ -221,7 +223,8 @@ const run = () => __awaiter(void 0, void 0, void 0, function* () {
     try {
         let minikubeVersion = (0, core_1.getInput)('minikube-version').toLowerCase();
         minikubeVersion = minikubeVersion === 'stable' ? 'latest' : minikubeVersion;
-        yield (0, download_1.downloadMinikube)(minikubeVersion);
+        const binPath = (0, core_1.getInput)('bin-path');
+        yield (0, download_1.downloadMinikube)(minikubeVersion, binPath);
         yield (0, start_1.startMinikube)();
     }
     catch (error) {
@@ -338,6 +341,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.startMinikube = void 0;
 const exec_1 = __nccwpck_require__(1514);
+const core_1 = __nccwpck_require__(2186);
 const cache_1 = __nccwpck_require__(3782);
 const inputs_1 = __nccwpck_require__(6180);
 const none_driver_1 = __nccwpck_require__(5516);
@@ -346,7 +350,8 @@ const startMinikube = () => __awaiter(void 0, void 0, void 0, function* () {
     (0, inputs_1.setArgs)(args);
     const cacheHits = yield (0, cache_1.restoreCaches)();
     yield (0, none_driver_1.installNoneDriverDeps)();
-    yield (0, exec_1.exec)('minikube', args);
+    const binPath = (0, core_1.getInput)('bin-path');
+    yield (0, exec_1.exec)('minikube', args, { cwd: binPath });
     yield (0, cache_1.saveCaches)(cacheHits);
 });
 exports.startMinikube = startMinikube;

--- a/src/download.ts
+++ b/src/download.ts
@@ -19,11 +19,12 @@ export const getDownloadURL = (version: string): string => {
   }
 }
 
-export const downloadMinikube = async (version: string): Promise<void> => {
+export const downloadMinikube = async (version: string, binPath?: string): Promise<void> => {
   const url = getDownloadURL(version)
   const downloadPath = await downloadTool(url)
-  const binPath =
-    getPlatform() === 'darwin' ? '/Users/runner/bin' : '/home/runner/bin'
+  if (!binPath) {
+    binPath = getPlatform() === 'darwin' ? '/Users/runner/bin' : '/home/runner/bin'
+  }
   await mkdirP(binPath)
   await exec('chmod', ['+x', downloadPath])
   await cp(downloadPath, join(binPath, 'minikube'))

--- a/src/download.ts
+++ b/src/download.ts
@@ -19,15 +19,19 @@ export const getDownloadURL = (version: string): string => {
   }
 }
 
-export const downloadMinikube = async (version: string, binPath?: string): Promise<void> => {
+export const downloadMinikube = async (
+  version: string,
+  installPath?: string
+): Promise<void> => {
   const url = getDownloadURL(version)
   const downloadPath = await downloadTool(url)
-  if (!binPath) {
-    binPath = getPlatform() === 'darwin' ? '/Users/runner/bin' : '/home/runner/bin'
+  if (!installPath) {
+    installPath =
+      getPlatform() === 'darwin' ? '/Users/runner/bin' : '/home/runner/bin'
   }
-  await mkdirP(binPath)
+  await mkdirP(installPath)
   await exec('chmod', ['+x', downloadPath])
-  await cp(downloadPath, join(binPath, 'minikube'))
+  await cp(downloadPath, join(installPath, 'minikube'))
   await rmRF(downloadPath)
-  addPath(binPath)
+  addPath(installPath)
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,8 +8,8 @@ const run = async (): Promise<void> => {
   try {
     let minikubeVersion = getInput('minikube-version').toLowerCase()
     minikubeVersion = minikubeVersion === 'stable' ? 'latest' : minikubeVersion
-    const binPath = getInput('bin-path');
-    await downloadMinikube(minikubeVersion, binPath)
+    const installPath = getInput('install-path')
+    await downloadMinikube(minikubeVersion, installPath)
     await startMinikube()
   } catch (error) {
     if (error instanceof Error) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,7 +8,8 @@ const run = async (): Promise<void> => {
   try {
     let minikubeVersion = getInput('minikube-version').toLowerCase()
     minikubeVersion = minikubeVersion === 'stable' ? 'latest' : minikubeVersion
-    await downloadMinikube(minikubeVersion)
+    const binPath = getInput('bin-path');
+    await downloadMinikube(minikubeVersion, binPath)
     await startMinikube()
   } catch (error) {
     if (error instanceof Error) {

--- a/src/start.ts
+++ b/src/start.ts
@@ -10,7 +10,7 @@ export const startMinikube = async (): Promise<void> => {
   setArgs(args)
   const cacheHits = await restoreCaches()
   await installNoneDriverDeps()
-  const binPath = getInput('bin-path')
-  await exec('minikube', args, {cwd: binPath})
+  const installPath = getInput('install-path')
+  await exec('minikube', args, {cwd: installPath})
   await saveCaches(cacheHits)
 }

--- a/src/start.ts
+++ b/src/start.ts
@@ -1,4 +1,5 @@
 import {exec} from '@actions/exec'
+import {getInput} from '@actions/core'
 
 import {restoreCaches, saveCaches} from './cache'
 import {setArgs} from './inputs'
@@ -9,6 +10,7 @@ export const startMinikube = async (): Promise<void> => {
   setArgs(args)
   const cacheHits = await restoreCaches()
   await installNoneDriverDeps()
-  await exec('minikube', args)
+  const binPath = getInput('bin-path')
+  await exec('minikube', args, {cwd: binPath})
   await saveCaches(cacheHits)
 }


### PR DESCRIPTION
This PR adds an optional `bin-path` action argument such that the directory where minikube gets installed can be configured. This is useful for self-hosted runners where the hardcoded `/home/runner` doesn't necessarily exists. 