### PR TITLE
:up: update node16 -> 20

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8
         with:
           node-version: 20
       - run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        with:
+          node-version: 20
       - run: |
           npm ci
           npm run all

--- a/action.yml
+++ b/action.yml
@@ -78,5 +78,5 @@ inputs:
     required: false
     default: ''
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
Hi,

I've confirmed that npm run all passes successfully, which looks good to me. Additionally, I've noticed that @types/node is already updated to the 20.x series.

This PR is related to issue #382.