### PR TITLE
docs: add other minikube example

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,7 @@ jobs:
 ## Real World: 
 #### Add your own repo here:
 - [medyagh/test-minikube-example](https://github.com/medyagh/test-minikube-example)
+- [AET-DevOps25/team-404-name-not-found](https://github.com/AET-DevOps25/team-404-name-not-found)
 - [More examples](https://github.com/medyagh/setup-minikube/tree/master/examples)
 
 ## About Author


### PR DESCRIPTION
While working on a university course, I came across this action. It works well thus far and we intend to write some more integration tests. It'd be nice to see it referenced in the readme as well :D