### PR TITLE
fix: create /etc/cni/net.d before chmod in none driver

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -149653,7 +149653,10 @@ const installCrictl = () => none_driver_awaiter(void 0, void 0, void 0, function
     ]);
 });
 const makeCniDirectoryReadable = () => none_driver_awaiter(void 0, void 0, void 0, function* () {
-    // created by podman package with 700 root:root
+    // Historically created by the podman package with 700 root:root, but
+    // newer runner images do not ship the directory at all, so create it
+    // before fixing permissions.
+    yield (0,lib_exec.exec)('sudo', ['mkdir', '-p', '/etc/cni/net.d']);
     yield (0,lib_exec.exec)('sudo', ['chmod', '755', '/etc/cni/net.d']);
 });
 const installNoneDriverDeps = () => none_driver_awaiter(void 0, void 0, void 0, function* () {

--- a/src/none-driver.ts
+++ b/src/none-driver.ts
@@ -74,7 +74,10 @@ const installCrictl = async (): Promise<void> => {
 }
 
 const makeCniDirectoryReadable = async (): Promise<void> => {
-  // created by podman package with 700 root:root
+  // Historically created by the podman package with 700 root:root, but
+  // newer runner images do not ship the directory at all, so create it
+  // before fixing permissions.
+  await exec('sudo', ['mkdir', '-p', '/etc/cni/net.d'])
   await exec('sudo', ['chmod', '755', '/etc/cni/net.d'])
 }
 


### PR DESCRIPTION
Fixes #835.

`makeCniDirectoryReadable()` assumed `/etc/cni/net.d` already exists (historically created by the podman package on runner images). Current `ubuntu-22.04` runner images no longer ship the directory, so `driver: none` setup fails deterministically:

```
/usr/bin/sudo chmod 755 /etc/cni/net.d
chmod: cannot access '/etc/cni/net.d': No such file or directory
Error: The process '/usr/bin/sudo' failed with exit code 1
```

This change runs `sudo mkdir -p /etc/cni/net.d` before the `chmod` — idempotent on images where the directory still exists with podman's 700 root:root, and repairs the missing-directory case.

Note on `dist/`: I applied the identical two-line change to `dist/index.js` by hand (mirroring the surrounding ncc output style) rather than committing a full `ncc` rebuild, to keep the diff reviewable. Happy to push a proper `npm run package` rebuild instead if you prefer.

Tested: we've been running this exact patch in our CI (via a pinned fork tag) with `driver: none`; the setup step and the full E2E suite behind it pass.
